### PR TITLE
Implemented save method in the helper

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,4 +5,9 @@ const bmHelper = require('./lib/bitmap-file-helper.js');
 bmHelper.load('./img/palette-bitmap.bmp', function(err, bitMapData) {
   // console.log(bitMapData.colors[28]);
   console.dir(bitMapData);
+
+  bmHelper.save('./img/test.bmp', bitMapData, function(err, data) {
+    if(err) console.log('error:', err); //TODO: Just log for test
+    console.log('data:', data);
+  });
 });

--- a/lib/bitmap-file-helper.js
+++ b/lib/bitmap-file-helper.js
@@ -16,5 +16,8 @@ exports.load = function(filepath, callback) {
 };
 
 exports.save = function(filepath, bitmap, callback) {
-
+  fs.writeFile(filepath, bitmap.buf, function(err, data) {
+    if(err) return callback(err);
+    callback(null, data);
+  });
 };

--- a/model/bitmap-constructor.js
+++ b/model/bitmap-constructor.js
@@ -2,6 +2,7 @@
 
 //NOTE: I prefer buf to buff -Geoff
 function Bitmap(buf) {
+  this.buf = buf;
   this.type = buf.toString('utf-8', 0, 2);
 
   // TODO: check that the type is what we can handle/expect.


### PR DESCRIPTION
We now store the buffer as a property in our
bitmaps. When you save a bitmap, it writes
this buffer back to the supplied filename.
NOTE: We currently have arrays for colors and
pixels, but changes to those arrays will not
alter the underlying buffer. We need to change
our implementation to deal with this.