### PR TITLE
Moved buffer access into getter methods

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,9 +2,15 @@
 
 const bmHelper = require('./lib/bitmap-file-helper.js');
 
+//TODO: I suggest we change bitMapData to bitmap. -Geoff
 bmHelper.load('./img/palette-bitmap.bmp', function(err, bitMapData) {
   // console.log(bitMapData.colors[28]);
-  console.dir(bitMapData);
+  // console.dir(bitMapData);
+  // for(var prop in bitMapData) {
+  //   console.log(prop);
+  // }
+  console.log(bitMapData.getColorArray());
+  console.log(bitMapData.getPixelArray());
 
   bmHelper.save('./img/test.bmp', bitMapData, function(err, data) {
     if(err) console.log('error:', err); //TODO: Just log for test

--- a/model/bitmap-constructor.js
+++ b/model/bitmap-constructor.js
@@ -1,50 +1,98 @@
 'use strict';
 
-//NOTE: I prefer buf to buff -Geoff
 function Bitmap(buf) {
+  //TODO: What happens if !buf ?
+  //TODO: Make buf a private property.
   this.buf = buf;
-  this.type = buf.toString('utf-8', 0, 2);
+  // this.type = buf.toString('utf-8', 0, 2);
 
   // TODO: check that the type is what we can handle/expect.
 
-  this.size = buf.readInt32LE(2);
-
-  var pixelOffset = buf.readUInt32LE(10);
-  // console.log(pixelOffset);
-
-  var dibSize = buf.readUInt32LE(14);
-  // console.log(dibSize);
-
-  this.width = buf.readUInt32LE(18);
-  this.height = buf.readUInt32LE(22);
-  this.bitsPerPixel = buf.readUInt16LE(28);
-  var numColors = buf.readInt32LE(46);
-
-  // TODO: Verify that numColors > 0
-
-  this.colors = [];
-  var pos = dibSize + 14;
-  for(let i = 0; i < numColors; i++) {
-    var color = {};
-    color.blue  = buf.readUInt8(pos++);
-    color.green = buf.readUInt8(pos++);
-    color.red   = buf.readUInt8(pos++);
-    color.alpha = buf.readUInt8(pos++);
-    this.colors.push(color);
-  }
-
-  var numPixels = this.width * this.height;
-  this.pixels = [];
-  for (let i = 0; i < numPixels; i++) {
-    var offset = pixelOffset + i;
-    this.pixels.push(buf.readUInt8(offset));
-  }
+  // this.size = buf.readInt32LE(2);
+  //
+  // var pixelOffset = buf.readUInt32LE(10);
+  //
+  // var dibSize = buf.readUInt32LE(14);
+  //
+  // this.width = buf.readUInt32LE(18);
+  // this.height = buf.readUInt32LE(22);
+  // // this.bitsPerPixel = buf.readUInt16LE(28);
+  //
+  // var numColors = buf.readInt32LE(46);
+  //
+  // // TODO: Verify that numColors > 0
+  //
+  // this.colors = [];
+  // var pos = dibSize + 14;
+  // for(let i = 0; i < numColors; i++) {
+  //   var color = {};
+  //   color.blue  = buf.readUInt8(pos++);
+  //   color.green = buf.readUInt8(pos++);
+  //   color.red   = buf.readUInt8(pos++);
+  //   color.alpha = buf.readUInt8(pos++);
+  //   this.colors.push(color);
+  // }
+  //
+  // var numPixels = this.width * this.height;
+  // this.pixels = [];
+  // for (let i = 0; i < numPixels; i++) {
+  //   var offset = pixelOffset + i;
+  //   this.pixels.push(buf.readUInt8(offset));
+  // }
   // the first row of the image is the bottom row
 
 }
-Bitmap.prototype.transform = function(operator) {
 
+//TODO: Consider the following alternative to setting
+//      each method individually:
+/*
+Bitmap.prototype = {
+  getType: function() { ... },
+  getWidth: function() { ... },
+  ...
 };
+*/
+
+Bitmap.prototype.getType = function() {
+  return this.buf.toString('utf-8', 0, 2);
+};
+Bitmap.prototype.getWidth = function() {
+  return this.buf.readUInt32LE(18);
+};
+Bitmap.prototype.getHeight = function() {
+  return this.buf.readUInt32LE(22);
+};
+Bitmap.prototype.getColorArray = function() {
+  var numColors = this.buf.readInt32LE(46);
+  var dibSize = this.buf.readUInt32LE(14);
+
+  // TODO: Verify that numColors > 0
+
+  var colors = [];
+  var pos = dibSize + 14;
+  for(let i = 0; i < numColors; i++) {
+    var color = {};
+    color.blue  = this.buf.readUInt8(pos++);
+    color.green = this.buf.readUInt8(pos++);
+    color.red   = this.buf.readUInt8(pos++);
+    color.alpha = this.buf.readUInt8(pos++);
+    colors.push(color);
+  }
+  return colors;
+};
+Bitmap.prototype.getPixelArray = function() {
+  var pixelOffset = this.buf.readUInt32LE(10);
+  var numPixels = this.getWidth() * this.getHeight();
+  var pixels = [];
+  for (let i = 0; i < numPixels; i++) {
+    var offset = pixelOffset + i;
+    pixels.push(this.buf.readUInt8(offset));
+  }
+  return pixels;
+};
+
+Bitmap.prototype.transform = function(operator) {
+}
 
 module.exports = exports = {};
 exports.Bitmap = Bitmap;


### PR DESCRIPTION
The constructor method was not ideal, because by creating
color and pixel arrays as properties, we were duplicating
that data in memory. Not only that, but it would increase
the complexity of the save operation to the point where
our helper would have to be a bit smarter. The goal is
to keep all the logic in the bitmap constructor file, and
use the buffer directly inside.