### PR TITLE
Added a parameterized transform constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,9 +19,17 @@ bmHelper.load('./img/palette-bitmap.bmp', function(err, bitMapData) {
   // });
 
   // makeBlackAndSave(bitMapData);
-  rotateRightAndSave(bitMapData);
-
+  // rotateRightAndSave(bitMapData);
+  rotate180AndSave(bitMapData);
 });
+
+function rotate180AndSave(bitmap) {
+  bitmap.transform(transforms.rotate(180));
+  bmHelper.save('./temp/rotated-180.bmp', bitmap, function(err) {
+    if(err) console.log(err);
+    console.log('saved rotated 180 bmp');
+  });
+}
 
 function rotateRightAndSave(bitmap) {
   bitmap.transform(transforms.rotateRight);

--- a/model/transform-constructor.js
+++ b/model/transform-constructor.js
@@ -25,3 +25,20 @@ exports.rotateRight = function(bitmap) {
 
   bitmap.setPixelArray(dest);
 };
+
+// example of a constructor that takes in a param and returns
+//  the transform function that uses the param.
+exports.rotate = function(angle) {
+  if(!angle) throw new Error('missing angle param');
+  if(angle % 90 !== 0) throw new Error('angle not a multiple of 90');
+  return function(bitmap) {
+    var steps = angle / 90;
+    var phase = steps % 4;
+    // -3 < phase < 3
+    if(phase < 0) phase += 4;
+    // 0 < phase < 3
+    for(let i = 0; i < phase; i++) {
+      bitmap.transform(exports.rotateRight);
+    }
+  };
+};

--- a/test/transform-constructor-test.js
+++ b/test/transform-constructor-test.js
@@ -37,4 +37,17 @@ describe('Transform Constructor', function() {
       });
     });
   });
+
+  describe('#rotate', function() {
+    it('should fail with bogus angles', function() {
+      //TODO: expect(transforms.rotate(55)).to.fail();
+      //Q: Will a bad or missing angle throw an error, or what?
+    });
+    it('should handle negative angles in multiples of 90', function() {
+
+    });
+    it('should handle positive angles in multiples of 90', function() {
+
+    });
+  });
 });


### PR DESCRIPTION
This has a nice example of a transform constructor that takes in a parameter. This will be really useful for color filters that might take in a mask, filter, alpha, or other kinds of params to alter bitmaps. I've also started organizing some of the high level test code in index.js, but we should probably move or get rid of that at some point. I would think index.js should maybe be for the command line interface, but we might also have some file like transform-bitmap.js.